### PR TITLE
add id to brands without ids

### DIFF
--- a/lib/branding-transform.js
+++ b/lib/branding-transform.js
@@ -3,8 +3,9 @@
 const getBranding = require('ft-n-article-branding');
 const tagTransform = require('./tag-transform');
 const isCommentTag = require('./utils/is-comment-tag');
+const primaryTagTransform = require('./primary-tag-transform');
 
-module.exports = (content) => {
+module.exports = content => {
 	const metadata = content.metadata || content.tags;
 
 	if (content.branding && content.branding.taxonomy === 'authors') {
@@ -24,6 +25,7 @@ module.exports = (content) => {
 			const author = content.authors[0];
 				brand = {
 					title: author.name,
+					id: author.idV1,
 					url: author.url,
 					headshot: author.headshot,
 				};
@@ -41,6 +43,8 @@ module.exports = (content) => {
 			type: 'editors-pick'
 		};
 	}
-
+	if (brand && !(brand.id || brand.idV1)) {
+		brand.id = primaryTagTransform(content).id;
+	}
 	return [branding, brand];
 };


### PR DESCRIPTION
To handle scenarios where brands do not have ids to feed into related stories.