### PR TITLE
add full url property

### DIFF
--- a/models/basic.js
+++ b/models/basic.js
@@ -3,6 +3,7 @@ module.exports = content => {
 	return {
 		id: content.id,
 		url: content.url && content.url.replace(/https:\/\/www.ft.com/, ''),
+		fullUrl: content.url,
 		title: content.title,
 		published: content.initialPublishedDate || content.published,
 		lastPublished: content.publishedDate || content.lastPublished,

--- a/tests/models/basic.test.js
+++ b/tests/models/basic.test.js
@@ -7,10 +7,11 @@ describe('Basic model transform', () => {
 
 	it('returns the expected properties', () => {
 		const result = subject(content);
-		expect(Object.keys(result).length).to.equal(6);
+		expect(Object.keys(result).length).to.equal(7);
 		expect(result).to.have.all.keys([
 			'id',
 			'url',
+			'fullUrl',
 			'title',
 			'published',
 			'lastPublished',


### PR DESCRIPTION
There is a url property that has the initial path (https://www.ft.com) removed to enable it to work on a relative basis.

However the full url is required to power sharing urls, eg. twitter.

This PR puts in a fullUrl property.